### PR TITLE
Fix/validator errors

### DIFF
--- a/test/complexValidation/complexValidation.test.js
+++ b/test/complexValidation/complexValidation.test.js
@@ -48,10 +48,25 @@ describe('ValidateRequest method', () => {
   });
 
   describe('validate combined schemas', () => {
-    it('throw an error when validating combined schemas', () => {
+    it('should throw an error when validating combined schemas', () => {
       expect(() => {
         validateResponse({ id: 'id' }, '/api/v1/song/{id}', 'get', 200, 'application/json');
       }).toThrow('Error in response: Schema IntrumentalSong should have required property \'title\', Schema PopSong should have required property \'title\', should match exactly one schema in oneOf. You provide "{"id":"id"}"');
+    });
+
+    it('should throw an error when validating combined inside a different schemas', () => {
+      expect(() => {
+        validateResponse({ value: false }, '/api/v1/internal/reference', 'get', 200, 'application/json');
+      }).toThrow('Error in response: should be string, should be number, Schema CustomError should be object, should match exactly one schema in oneOf, Schema PopSong should have required property \'title\', should match exactly one schema in oneOf. You provide "{"value":false}"');
+    });
+
+    it.skip('should not throw an error when validating combined inside a different schemas', () => {
+      let result = validateResponse({ title: 'title' }, '/api/v1/internal/reference', 'get', 200, 'application/json');
+      expect(result).toBeTruthy();
+      result = validateResponse({ value: 1 }, '/api/v1/internal/reference', 'get', 200, 'application/json');
+      expect(result).toBeTruthy();
+      result = validateResponse({ value: { message: 'valid message' } }, '/api/v1/internal/reference', 'get', 200, 'application/json');
+      expect(result).toBeTruthy();
     });
   });
 });

--- a/test/complexValidation/fake-server.js
+++ b/test/complexValidation/fake-server.js
@@ -101,3 +101,27 @@ app.get('/api/v1/song/:id', (req, res) => (
     title: 'abum 1',
   })
 ));
+
+/**
+ * Test schema
+ * @typedef {object} CustomError
+ * @property {string} message
+ */
+
+/**
+ * Test schema
+ * @typedef {object} TestSchema
+ * @property {string|number|CustomError} value - Property with multiple type support
+ */
+
+/**
+ * GET /api/v1/internal/reference
+ * @summary This is the summary or description of the endpoint
+ * @tags album
+ * @return {TestSchema|PopSong} 200 - success response - application/json
+ */
+app.get('/api/v1/internal/reference', (req, res) => (
+  res.json({
+    title: 'abum 1',
+  })
+));

--- a/test/complexValidation/mock.json
+++ b/test/complexValidation/mock.json
@@ -99,6 +99,36 @@
             "type": "integer"
           }
         }
+      },
+      "CustomError": {
+        "description": "Test schema",
+        "type": "object",
+        "properties": {
+          "message": {
+            "description": "",
+            "type": "string"
+          }
+        }
+      },
+      "TestSchema": {
+        "description": "Test schema",
+        "type": "object",
+        "properties": {
+          "value": {
+            "description": "Property with multiple type support",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "$ref": "#/components/schemas/CustomError"
+              }
+            ]
+          }
+        }
       }
     }
   },
@@ -291,6 +321,36 @@
             }
           }
         ],
+        "tags": [
+          "album"
+        ]
+      }
+    },
+    "/api/v1/internal/reference": {
+      "get": {
+        "deprecated": false,
+        "summary": "This is the summary or description of the endpoint",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/TestSchema"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PopSong"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
         "tags": [
           "album"
         ]

--- a/utils/formatReferences.js
+++ b/utils/formatReferences.js
@@ -22,8 +22,13 @@ const formatExceptions = (key, values) => {
   if (EXCEPTIONS.includes(key)) {
     return {
       [key]: values
-        .map(value => formatRefKey('$ref', value.$ref))
-        .filter(({ $ref }) => $ref),
+        .map(value => {
+          if (value.type) {
+            return value;
+          }
+          return formatRefKey('$ref', value.$ref);
+        })
+        .filter(({ $ref, type }) => $ref || type),
     };
   }
   return {};


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Bugfix

### Description:
We had a problem with `oneOf`, `anyOf`, `allOf` keys when we mixed with types that were not references.

This problem was in this function:

```js
const formatExceptions = (key, values) => {
  if (EXCEPTIONS.includes(key)) {
    return {
      [key]: values
        .map(value => formatRefKey('$ref', value.$ref))
        .filter(({ $ref }) => $ref), // here
    };
  }
  return {};
};
```
As we were filtering by `$ref`.


This closes #34 


