### PR TITLE
Fix/null references

### DIFF
--- a/test/complexValidation/complexValidation.test.js
+++ b/test/complexValidation/complexValidation.test.js
@@ -68,5 +68,18 @@ describe('ValidateRequest method', () => {
       result = validateResponse({ value: { message: 'valid message' } }, '/api/v1/internal/reference', 'get', 200, 'application/json');
       expect(result).toBeTruthy();
     });
+
+    it('validate combined schema when it is null reference and object', () => {
+      let result = validateResponse({
+        title: 'example',
+        objectReference: null,
+      }, '/api/v1/object/reference', 'get', 200, 'application/json');
+      expect(result).toBeTruthy();
+      result = validateResponse({
+        title: 'example',
+        objectReference: { message: 'object reference message' },
+      }, '/api/v1/object/reference', 'get', 200, 'application/json');
+      expect(result).toBeTruthy();
+    });
   });
 });

--- a/test/complexValidation/fake-server.js
+++ b/test/complexValidation/fake-server.js
@@ -125,3 +125,28 @@ app.get('/api/v1/internal/reference', (req, res) => (
     title: 'abum 1',
   })
 ));
+
+/**
+ * Object schema
+ * @typedef {object} ObjectReference
+ * @property {string} message
+ */
+
+/**
+ * Object schema
+ * @typedef {object} ObjectReferenceResponse
+ * @property {string} title
+ * @property {ObjectReference|null} objectReference
+ */
+
+/**
+ * GET /api/v1/object/reference
+ * @summary This is the summary or description of the endpoint
+ * @tags album
+ * @return {ObjectReferenceResponse} 200 - success response - application/json
+ */
+app.get('/api/v1/object/reference', (req, res) => (
+  res.json({
+    title: 'abum 1',
+  })
+));

--- a/test/complexValidation/mock.json
+++ b/test/complexValidation/mock.json
@@ -132,6 +132,31 @@
             ]
           }
         }
+      },
+      "ObjectReference": {
+        "description": "Object schema",
+        "type": "object",
+        "properties": {
+          "message": {
+            "description": "",
+            "type": "string"
+          }
+        }
+      },
+      "ObjectReferenceResponse": {
+        "description": "Object schema",
+        "type": "object",
+        "properties": {
+          "title": {
+            "description": "",
+            "type": "string"
+          },
+          "objectReference": {
+            "description": "",
+            "nullable": true,
+            "$ref": "#/components/schemas/ObjectReference"
+          }
+        }
       }
     }
   },
@@ -348,6 +373,29 @@
                       "$ref": "#/components/schemas/PopSong"
                     }
                   ]
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "tags": [
+          "album"
+        ]
+      }
+    },
+    "/api/v1/object/reference": {
+      "get": {
+        "deprecated": false,
+        "summary": "This is the summary or description of the endpoint",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObjectReferenceResponse"
                 }
               }
             }

--- a/test/validateRequest/validateRequest.test.js
+++ b/test/validateRequest/validateRequest.test.js
@@ -58,6 +58,11 @@ describe('ValidateRequest method', () => {
     });
 
     it('should validate object type with reference', () => {
+      const result = validateRequest({ title: 'request title' }, '/api/v1/songs', 'post');
+      expect(result).toBeTruthy();
+    });
+
+    it('should validate object type with reference and nullable value', () => {
       const result = validateRequest({ title: null }, '/api/v1/songs', 'post');
       expect(result).toBeTruthy();
     });


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [X] Bugfix
 - [X] Feature
 
### Description:
This PR fixes a problem when we receive schemas like this one:

```json
{
   "objectReference": {
      "description": "",
      "nullable": true,
      "$ref": "#/components/schemas/ObjectReference"
   }
 }
```

Because we have to convert in schemas with this structure so that AJV validator works.

```json
  {
    "objectReference": {
      "description": "",
      "nullable": true,
      "anyOf": [
        {
          "$ref": "#/components/schemas/ObjectReference"
        },
        {
           "type": "null"
         }
      ]
    }
  }
```