### PR TITLE
fix: don't override user value for `strictValidation` flag

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -1,0 +1,11 @@
+module.exports = {
+  // Options to override default ajv settings (https://ajv.js.org/options.html)
+  ajvConfig: {},
+
+  // Custom error handler
+  errorHandler: null,
+
+  // If enabled, validation will throw errors if the payload has additional
+  // properties not defined in the schema
+  strictValidation: true,
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const Ajv = require('ajv').default;
 const addFormats = require('ajv-formats');
+const defaultOptions = require('./config/default');
 const {
   formatComponents,
   configError,
@@ -53,7 +54,7 @@ const {
 /**
  * @name ValidateRequiredValues
  * @function
-  * @param {*} value Values we want to see if are send as required parameters
+ * @param {*} value Values we want to see if are send as required parameters
  * @param {string} endpoint OpenApi endpoint we want to validate
  * @param {string} method OpenApi method we want to validate
  */
@@ -76,13 +77,19 @@ const {
  * @param {object} options Options to extend the errorHandler or Ajv configuration
  * @returns {ValidatorMethods} validator methods
  */
-const validate = (openApiDef, options = {}) => {
+const validate = (openApiDef, userOptions = {}) => {
+  const options = {
+    ...defaultOptions,
+    ...(userOptions || {}),
+  };
+
+  const { errorHandler } = options;
   const inputValidationError = inputValidation(openApiDef);
-  const errorHandler = options ? options.errorHandler : null;
   configError(inputValidationError, errorHandler);
-  const optionsValidationError = optionsValidation(options);
+  const optionsValidationError = optionsValidation(userOptions);
   configError(optionsValidationError, errorHandler);
-  const schemaOptions = { strictValidation: options.strictValidation || true };
+
+  const schemaOptions = { strictValidation: options.strictValidation };
   const defsSchema = {
     $id: 'defs.json',
     definitions: {


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [x] Bugfix
 - [ ] Feature
 - [ ] Test
 - [ ] Docs
 - [x] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:
There was an issue with the `strictValidation` option always being set to `true` regardless of the value specified by the user:

```
const schemaOptions = { strictValidation: options.strictValidation || true };
```

If the user decided they wanted to disable this option by manually setting `strictValidation` to `false`, the use of the `||` operator caused the value to always be overriden by the defaults. 

This PR introduces a new file with a default configuration object, which will be merged with the user specified options when the `validate` method runs. With this change user settings will always take precendence, so the value they assign to the `strictValidation` option (or any other of the available options) will always be preserved. 