### PR TITLE
allow params at endpoint level and validate them concatenated

### DIFF
--- a/test/validateParams/mock.json
+++ b/test/validateParams/mock.json
@@ -209,6 +209,58 @@
         ],
         "tags": []
       }
+    },
+    "/api/v2/albums/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "",
+          "required": false,
+          "deprecated": false,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "get": {
+        "deprecated": false,
+        "summary": "This is the summary or description of the endpoint",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": []
+      }
+    },
+    "/api/v3/albums/{id}": {
+      "get": {
+        "deprecated": false,
+        "summary": "This is the summary or description of the endpoint",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "success response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "tags": []
+      }
     }
   },
   "tags": []

--- a/test/validateParams/validateParams.test.js
+++ b/test/validateParams/validateParams.test.js
@@ -110,6 +110,17 @@ describe('validateParams method', () => {
         validatePathParam('non-valid', 'name', '/api/v2/{id}', 'get');
       }).toThrow('Error in path: must be boolean. You provide "non-valid"');
     });
+
+    it('should be valid. Param is defined at endpoint level', () => {
+      expect(() => {
+        validatePathParam(12345, 'id', '/api/v2/albums/{id}', 'get');
+      }).toBeTruthy();
+    });
+    it('should throw error. no parameter definition at endpoint level', () => {
+      expect(() => {
+        validatePathParam(12345, 'id', '/api/v3/albums/{id}', 'get');
+      }).toThrow('Method: "get" and Endpoint: "/api/v3/albums/{id}" does not have parameters definition');
+    });
   });
 });
 

--- a/validators/endpointValidation.js
+++ b/validators/endpointValidation.js
@@ -17,7 +17,7 @@ const common = (definition, endpoint, method, type) => {
   if (!definition.paths[endpoint][method]) {
     return responseBuilder(false, `Method: "${method}" not found in the OpenAPI definition for "${endpoint}" endpoint`);
   }
-  if (!definition.paths[endpoint][method][type]) {
+  if ((type === 'parameters' && !(definition.paths[endpoint][type] || definition.paths[endpoint][method][type])) || !definition.paths[endpoint][method][type]) {
     return responseBuilder(false, `Method: "${method}" and Endpoint: "${endpoint}" does not have ${type} definition`);
   }
   return responseBuilder(true);
@@ -75,7 +75,9 @@ const params = (definition, endpoint, method, key, type) => {
   if (!commonValidation.valid) {
     return commonValidation;
   }
-  const parameter = definition.paths[endpoint][method].parameters
+  const endpointParameters = definition.paths[endpoint].parameters || [];
+  const methodParameters = definition.paths[endpoint][method].parameters || [];
+  const parameter = endpointParameters.concat(methodParameters)
     .filter(({ in: paramType }) => paramType === type)
     .find(({ name }) => name === key);
   if (!parameter) {


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)
 - [ ] Bugfix
 - [ X] Feature
 - [ ] Test
 - [ ] Docs
 - [ ] Refactor
 - [ ] Build-related changes
 - [ ] Other, please describe:

### Description:
OAS allows param definitions at endpoint level but openapi-validator-utils only checks params at method level. This enhancement allows both.
See: https://swagger.io/docs/specification/describing-parameters/  "Common Parameters for All Methods of a Path"